### PR TITLE
Fix current patron logos to load over HTTPS.

### DIFF
--- a/messages.xml
+++ b/messages.xml
@@ -221,7 +221,7 @@
         <caption>Templating Jenkins Environments with Docker</caption>
         <link>https://www.cloudbees.com/blog/templating-jenkins-build-environments-docker-containers</link>
         <blurb>Read this Blog to Learn How</blurb>
-        <logo>http://www.cloudbees.com/sites/default/files/cb-logo-clr.r-square78x78.png</logo>
+        <logo>https://www.cloudbees.com/sites/default/files/cb-logo-clr.r-square78x78.png</logo>
       </message>
     </slot>
 
@@ -231,7 +231,7 @@
         <caption>Jenkins and Docker</caption>
         <link>https://www.cloudbees.com/continuous-delivery/jenkins-docker</link>
         <blurb>Learn How to Accelerate Your Continuous Delivery Pipelines</blurb>
-        <logo>http://www.cloudbees.com/sites/default/files/cb-logo-clr.r-square78x78.png</logo>
+        <logo>https://www.cloudbees.com/sites/default/files/cb-logo-clr.r-square78x78.png</logo>
       </message>
     </slot>
 


### PR DESCRIPTION
Otherwise, because the wiki and patron messages are served over HTTPS, trying to load these images over HTTP may lead to mixed-content warnings, and broken images, depending on the browser setup.

![image](https://cloud.githubusercontent.com/assets/138615/11319187/971b80d2-906e-11e5-9ec3-7dc3001b6cb9.png)