### PR TITLE
Minor grammar update to current security advisory message.

### DIFF
--- a/messages.xml
+++ b/messages.xml
@@ -241,7 +241,7 @@
       <message>
         <caption>Security Advisory is your friend</caption>
         <link>https://wiki.jenkins-ci.org/display/JENKINS/Security+Advisories</link>
-        <blurb>Running Jenkins on the internet facing machine? You should pay attention to our security advisories</blurb>
+        <blurb>Running Jenkins on an internet-facing machine? You should pay attention to our security advisories</blurb>
         <logo>https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png</logo>
       </message>
     </slot>


### PR DESCRIPTION
This doesn't change the intent of the message, so I'm hoping this will be straightforward to merge.

The message title is also a bit questionable; perhaps in future is should be more directly phrased as a call to action.