### PR TITLE
[FIXED INFRA-547] Ensure that patron messages are opened in a new page.

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -54,13 +54,13 @@ def generate(msg,name) {
 <body style="margin:0; overflow:hidden">
   <div id="patron">
     <div style="float:right;">
-      <a class=ourl href="${link}">
+      <a class=ourl target="_blank" href="${link}">
         <img class=logo src="${logo}">
       </a>
     </div>
     <div class=inner>
-      <div class="color"><a href="${link}" target="top" id=ocaption class=ourl>${caption}</a></div>
-      <div class="color"><a href="${link}" target="top" id=olink class=ourl>${linkText}</a></div>
+      <div class="color"><a href="${link}" target="_blank" id=ocaption class=ourl>${caption}</a></div>
+      <div class="color"><a href="${link}" target="_blank" id=olink class=ourl>${linkText}</a></div>
       <div id=oblurb>${blurb}</div>
     </div>
   </div>


### PR DESCRIPTION
Previously, clicking on the icon would open within the message iframe itself.

The target "top" (presumably a typo of "_top") was also replaced with a valid target, "_blank", which has the same effect as the prior implementation, i.e. clicking on any link will open it in a new tab / window.